### PR TITLE
Updated Docker/Azure Compose and fixed title issue in app

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -25,6 +25,14 @@ def get_data():
 
 data = get_data()
 
+# --- Remove Hamburger Menu | https://docs.streamlit.io/knowledge-base/using-streamlit/how-hide-hamburger-menu-app ---
+hide_menu_style = """
+        <style>
+        #MainMenu {visibility: hidden;}
+        </style>
+        """
+st.markdown(hide_menu_style, unsafe_allow_html=True)
+
 # --- SIDEBAR ---
 with st.sidebar:
     st.header('CNU Data Data Dashboard')
@@ -76,7 +84,7 @@ if view == 'Last Game Stats':
                             barmode='group', 
                             labels={"variable": "Team"}, 
                             hover_data=['off', 'def','opp_off', 'opp_def'],
-                            title='Total Rebounds Per Last 5 Games')
+                            title=f'Total Rebounds Per Last {num_games} Games')
         total_rebs_chart.update_layout(xaxis_title='Game', 
                                 yaxis_title='Total Rebounds')
         
@@ -87,7 +95,7 @@ if view == 'Last Game Stats':
         x='opponent', 
         barmode='group', 
         labels={"variable": "Team"}, 
-        title='Total Turnovers Per Last 5 Games')
+        title=f'Total Turnovers Per Last {num_games} Games')
         total_turnover_chart.update_layout(xaxis_title='Game', 
                                         yaxis_title='Total Rebounds')
         
@@ -101,7 +109,7 @@ if view == 'Last Game Stats':
                             values=[fg_taken,threes_taken], 
                             names=['Field Goals Attempted', 'Threes Attempted'], 
                             hole=0.3, 
-                            title='Shot Makeup Over Last 5 Games')
+                            title=f'Shot Makeup Over Last {num_games} Games')
         total_shots.update_traces(textposition='outside', 
                                 textinfo='label+percent')
         

--- a/azure-compose.yml
+++ b/azure-compose.yml
@@ -1,22 +1,24 @@
 version: '3'
 services:
-  app:
-    image: nater55/cnumbbmlproject-app:latest
-    container-name: cnumbbstats-app
-    restart: unless-stopped
-    volumes:
-      - output:/app/output
-    command: streamlit run app.py --server.port=80
-    ports:
-      - 80:80
   web:
-    image: nater55/cnumbbmlproject-web:latest
+    image: nater55/cnumbbmlproject-web
     container-name: cnumbbstats-scraper
     restart: unless-stopped
     volumes:
       - output:/scraping/output
     ports:
       - 8080:8080
+  app:
+    image: nater55/cnumbbmlproject-app
+    container-name: cnumbbstats-app
+    depends-on:
+      - web
+    restart: unless-stopped
+    volumes:
+      - output:/app/output
+    command: streamlit run app.py --server.port=80
+    ports:
+      - 80:80
 
 volumes:
   output:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,6 @@
 version: '3.7'
 
 services:
-
-  app:
-    build: 
-      context: ./app
-      dockerfile: Dockerfile
-    platform: linux/amd64
-    restart: unless-stopped
-    volumes:
-      - ./output:/app/output
-    command: streamlit run app.py --server.port=80
-    ports:
-      - 80:80
   web:
     build:
       context: ./scraping
@@ -25,6 +13,19 @@ services:
       - ./output:/scraping/output
     ports:
       - 8080:8080
+  app:
+    build: 
+      context: ./app
+      dockerfile: Dockerfile
+    depends_on:
+      - web
+    platform: linux/amd64
+    restart: unless-stopped
+    volumes:
+      - ./output:/app/output
+    command: streamlit run app.py --server.port=80
+    ports:
+      - 80:80
 
 volumes:
   output:


### PR DESCRIPTION
Made the following fixes:
- Updated the docker compose to use the `depends-on` input so the web scraper is ran first
- Updated the azure compose to use the `depends-on` input so the web scraper is ran first
- Updated the azure compose and removed the `latest` from the docker image to see if it will pull the most recent deployed build
- fixed the issue where the graph titles on the game data page always said 5 games (even when the user wanted to display more games)